### PR TITLE
Improve swamp water variation and deferred spawns

### DIFF
--- a/src/main/java/goat/projectLinearity/ProjectLinearity.java
+++ b/src/main/java/goat/projectLinearity/ProjectLinearity.java
@@ -20,6 +20,7 @@ import goat.projectLinearity.advs.jungle.*;
 import goat.projectLinearity.commands.RegenerateCommand;
 import goat.projectLinearity.world.ConsegritySpawnListener;
 import goat.projectLinearity.world.RegionTitleListener;
+import goat.projectLinearity.world.DeferredSpawnManager;
 import goat.projectLinearity.world.ConsegrityRegions;
 import org.bukkit.*;
 import org.bukkit.advancement.Advancement;
@@ -66,6 +67,8 @@ public final class ProjectLinearity extends JavaPlugin implements Listener {
         Bukkit.getPluginManager().registerEvents(new ConsegritySpawnListener(), this);
         // Register region title listener
         Bukkit.getPluginManager().registerEvents(new RegionTitleListener(this), this);
+        // Initialize deferred spawn queue for generator-triggered spawns
+        DeferredSpawnManager.initialize(this);
     }
     public AdvancementTab desert;
     public AdvancementTab mesa;

--- a/src/main/java/goat/projectLinearity/world/DeferredSpawnManager.java
+++ b/src/main/java/goat/projectLinearity/world/DeferredSpawnManager.java
@@ -1,0 +1,90 @@
+package goat.projectLinearity.world;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.ChunkLoadEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Queues entity spawns while chunks are being generated and flushes them once
+ * the chunk has fully loaded on the main server thread. This avoids calling
+ * Bukkit entity APIs from inside the chunk generator which can run on a worker
+ * thread on modern server implementations.
+ */
+public final class DeferredSpawnManager implements Listener {
+    private static DeferredSpawnManager instance;
+
+    private final Plugin plugin;
+    private final Map<String, Map<Long, List<SpawnTask>>> pending = new ConcurrentHashMap<>();
+
+    private DeferredSpawnManager(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public static void initialize(Plugin plugin) {
+        if (instance != null) return;
+        instance = new DeferredSpawnManager(plugin);
+        Bukkit.getPluginManager().registerEvents(instance, plugin);
+    }
+
+    public static void queueEntitySpawn(World world, int chunkX, int chunkZ, double x, double y, double z, EntityType type) {
+        Objects.requireNonNull(world, "world");
+        Objects.requireNonNull(type, "type");
+        if (instance == null) {
+            // Should not happen, but guard to avoid NPEs if called very early.
+            initialize(JavaPlugin.getProvidingPlugin(DeferredSpawnManager.class));
+        }
+        instance.enqueue(world, chunkX, chunkZ, x, y, z, type);
+    }
+
+    private void enqueue(World world, int chunkX, int chunkZ, double x, double y, double z, EntityType type) {
+        long chunkKey = chunkKey(chunkX, chunkZ);
+        String worldName = world.getName();
+        pending
+            .computeIfAbsent(worldName, key -> new ConcurrentHashMap<>())
+            .computeIfAbsent(chunkKey, key -> Collections.synchronizedList(new ArrayList<>()))
+            .add(new SpawnTask(x, y, z, type));
+    }
+
+    @EventHandler
+    public void onChunkLoad(ChunkLoadEvent event) {
+        World world = event.getWorld();
+        Map<Long, List<SpawnTask>> byChunk = pending.get(world.getName());
+        if (byChunk == null || byChunk.isEmpty()) return;
+        long key = chunkKey(event.getChunk().getX(), event.getChunk().getZ());
+        List<SpawnTask> tasks = byChunk.remove(key);
+        if (tasks == null || tasks.isEmpty()) {
+            if (byChunk.isEmpty()) pending.remove(world.getName());
+            return;
+        }
+        if (byChunk.isEmpty()) pending.remove(world.getName());
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            for (SpawnTask task : tasks) {
+                try {
+                    Location location = new Location(world, task.x(), task.y(), task.z());
+                    world.spawnEntity(location, task.type());
+                } catch (Throwable ignored) {
+                }
+            }
+        });
+    }
+
+    private static long chunkKey(int chunkX, int chunkZ) {
+        return (((long) chunkX) << 32) ^ (chunkZ & 0xFFFFFFFFL);
+    }
+
+    private record SpawnTask(double x, double y, double z, EntityType type) {
+    }
+}

--- a/src/main/java/goat/projectLinearity/world/sector/SwampSector.java
+++ b/src/main/java/goat/projectLinearity/world/sector/SwampSector.java
@@ -1,8 +1,10 @@
 package goat.projectLinearity.world.sector;
 
 import goat.projectLinearity.world.ConsegrityRegions;
+import goat.projectLinearity.world.DeferredSpawnManager;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.entity.EntityType;
 import org.bukkit.generator.ChunkGenerator;
 
 import java.util.Random;
@@ -28,15 +30,12 @@ public class SwampSector extends SectorBase {
         int baseZ = chunkZ << 4;
         Material lily;
         try { lily = Material.valueOf("LILY_PAD"); } catch (Throwable t) { lily = Material.valueOf("WATER_LILY"); }
-        final double waterFrac = 0.40;
-        final double scale = 34.0;
         for (int lx = 0; lx < 16; lx++) {
             for (int lz = 0; lz < 16; lz++) {
                 if (regionGrid[lx][lz] != ConsegrityRegions.Region.SWAMP) continue;
                 int topY = topYGrid[lx][lz];
                 int wx = baseX + lx, wz = baseZ + lz;
-                double n = valueNoise2(seed ^ 0x5A4D00A1L, (double) wx / scale, (double) wz / scale);
-                boolean water = (n < waterFrac);
+                boolean water = shouldPlaceWater(seed, wx, wz);
                 if (water) {
                     data.setBlock(lx, topY, lz, Material.WATER);
                     if (rng.nextDouble() < 0.10 && safeType(data, lx, topY + 1, lz) == Material.AIR) {
@@ -57,8 +56,7 @@ public class SwampSector extends SectorBase {
             if (regionGrid[lx][lz] != ConsegrityRegions.Region.SWAMP) continue;
             int topY = topYGrid[lx][lz];
             int wx = baseX + lx, wz = baseZ + lz;
-            double n = valueNoise2(seed ^ 0x5A4D00A1L, (double) wx / scale, (double) wz / scale);
-            if (n < waterFrac) continue;
+            if (shouldPlaceWater(seed, wx, wz)) continue;
             if (slopeGrid(topYGrid, lx, lz) > 3) continue;
             Material ground = safeType(data, lx, topY, lz);
             if (ground != Material.GRASS_BLOCK && ground != Material.DIRT) continue;
@@ -66,6 +64,69 @@ public class SwampSector extends SectorBase {
             growSimpleTree(data, lx, topY + 1, lz, Material.OAK_LOG, Material.OAK_LEAVES, new Random(rng.nextLong()));
             if (rng.nextBoolean()) addVinesAround(data, lx, topY + 1, lz, rng);
         }
+
+        maybeQueueCows(world, data, chunkX, chunkZ, topYGrid, regionGrid, rng);
+        maybeQueueWitch(world, data, chunkX, chunkZ, topYGrid, regionGrid, rng);
+    }
+
+    private boolean shouldPlaceWater(long seed, int wx, int wz) {
+        double coarse = valueNoise2(seed ^ 0x5A4D00A1L, (double) wx / 58.0, (double) wz / 58.0);
+        double medium = valueNoise2(seed ^ 0x5A4D00B1L, (double) wx / 22.0, (double) wz / 22.0);
+        double fine = valueNoise2(seed ^ 0x5A4D00C1L, (double) wx / 9.0, (double) wz / 9.0);
+        double combined = coarse * 0.55 + medium * 0.30 + fine * 0.15;
+        double threshold = 0.47 + (valueNoise2(seed ^ 0x5A4D00D1L, (double) wx / 110.0, (double) wz / 110.0) - 0.5) * 0.18;
+        double rimMix = valueNoise2(seed ^ 0x5A4D00E1L, (double) wx / 6.0, (double) wz / 6.0) - 0.5;
+        double deviation = Math.abs(combined - threshold);
+        if (deviation < 0.05) {
+            double blend = (0.05 - deviation) / 0.05;
+            combined -= rimMix * 0.08 * blend;
+        }
+        return combined < threshold;
+    }
+
+    private void maybeQueueCows(World world, ChunkGenerator.ChunkData data, int chunkX, int chunkZ,
+                                int[][] topYGrid, ConsegrityRegions.Region[][] regionGrid, SplittableRandom rng) {
+        if (rng.nextDouble() >= 0.12) return;
+        int baseX = chunkX << 4, baseZ = chunkZ << 4;
+        int herd = 1 + rng.nextInt(2);
+        for (int count = 0; count < herd; count++) {
+            for (int attempts = 0; attempts < 8; attempts++) {
+                int lx = rng.nextInt(16), lz = rng.nextInt(16);
+                if (regionGrid[lx][lz] != ConsegrityRegions.Region.SWAMP) continue;
+                int y = topYGrid[lx][lz];
+                Material surface = safeType(data, lx, y, lz);
+                if (!isSolidSwampGround(surface)) continue;
+                if (safeType(data, lx, y + 1, lz) != Material.AIR) continue;
+                DeferredSpawnManager.queueEntitySpawn(world, chunkX, chunkZ,
+                        baseX + lx + 0.5, y + 1, baseZ + lz + 0.5, EntityType.COW);
+                break;
+            }
+        }
+    }
+
+    private void maybeQueueWitch(World world, ChunkGenerator.ChunkData data, int chunkX, int chunkZ,
+                                 int[][] topYGrid, ConsegrityRegions.Region[][] regionGrid, SplittableRandom rng) {
+        if (rng.nextInt(50) != 0) return;
+        int baseX = chunkX << 4, baseZ = chunkZ << 4;
+        for (int attempts = 0; attempts < 12; attempts++) {
+            int lx = rng.nextInt(16), lz = rng.nextInt(16);
+            if (regionGrid[lx][lz] != ConsegrityRegions.Region.SWAMP) continue;
+            int y = topYGrid[lx][lz];
+            Material surface = safeType(data, lx, y, lz);
+            if (!isSolidSwampGround(surface)) continue;
+            if (safeType(data, lx, y + 1, lz) != Material.AIR) continue;
+            DeferredSpawnManager.queueEntitySpawn(world, chunkX, chunkZ,
+                    baseX + lx + 0.5, y + 1, baseZ + lz + 0.5, EntityType.WITCH);
+            break;
+        }
+    }
+
+    private boolean isSolidSwampGround(Material material) {
+        return material == Material.GRASS_BLOCK
+                || material == Material.DIRT
+                || material == Material.MUD
+                || material == Material.MOSS_BLOCK
+                || material == Material.MYCELIUM;
     }
 }
 


### PR DESCRIPTION
## Summary
- blend multiple noise layers to create patchier swamp water pools while keeping dry ground grassy
- add deferred spawning of swamp cows and rare witches driven by a new spawn manager
- register the deferred spawn manager during plugin startup so generator-driven spawns run safely

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dd5f2cf5c083328dd5b2ed14f728f3