### PR TITLE
Prevent mountain taiga trees from being overwritten

### DIFF
--- a/src/main/java/goat/projectLinearity/world/sector/MountainSector.java
+++ b/src/main/java/goat/projectLinearity/world/sector/MountainSector.java
@@ -133,6 +133,9 @@ public class MountainSector extends SectorBase {
             int y = topYGrid[lx][lz];
             Material g = safeType(data, lx, y, lz);
             if (g != Material.GRASS_BLOCK && g != Material.DIRT && g != Material.SNOW_BLOCK && g != Material.STONE) continue;
+            // avoid reusing spots that already grew a tree (logs or other blocks above ground)
+            Material above = safeType(data, lx, y + 1, lz);
+            if (above != Material.AIR) continue;
             if (rng.nextDouble() < 0.45 && y + 2 < world.getMaxHeight() - 1) {
                 data.setBlock(lx, y + 1, lz, Material.DIRT);
                 data.setBlock(lx, y + 2, lz, Material.GRASS_BLOCK);


### PR DESCRIPTION
## Summary
- guard mountain taiga decoration from selecting spots that already contain blocks above the ground
- stop the dirt-and-grass mound pass from overwriting existing spruce trunks in the mountain sector

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd5fc38d6c8332b5fbc43f081e087b